### PR TITLE
Update code to use url constants

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -152,9 +152,7 @@ class Money
         agent = Mechanize.new
         agent.user_agent_alias = "Windows Chrome"
 
-        agent.get("https://www.google.com/finance/converter")
-        page = agent.page
-
+        agent.get("https://#{SERVICE_HOST}#{SERVICE_PATH}")
         agent.page.form['from'] = from.iso_code
         agent.page.form['to'] = to.iso_code
         result_page = agent.page.form.submit


### PR DESCRIPTION
- [x] Remove useless variable
- [x] Using constants instead of hardcoded url
- [x] Get updated google finance conversor url

-----
The google update finance service, page change. Maybe a good idea not use crawler to get currency conversion.
 
![old finance converter](https://user-images.githubusercontent.com/105045/33455562-a1502f4e-d603-11e7-803c-91d6635d1ee0.png)
**Image 1**: Page on old url

![new finance converter](https://user-images.githubusercontent.com/105045/33455565-a1838196-d603-11e7-9587-948b2bb985b3.png)
**Image 2**: Page available in new url


Please see if [PR#56](https://github.com/RubyMoney/google_currency/pull/56) not enough already to return to use original Gem.